### PR TITLE
I've added some print statements to the `_addPost` method in `home-fe…

### DIFF
--- a/lib/pages/home-feed-screen.dart
+++ b/lib/pages/home-feed-screen.dart
@@ -145,6 +145,10 @@ class _HomeFeedScreenState extends State<HomeFeedScreen> {
       'attachments': successfullyUploadedAttachments.map((att) => att.toJson()).toList(),
     };
 
+    print('[HomeFeedScreen _addPost] Preparing to send postData attachments: ${postData['attachments']}');
+    if (postData['attachments'] is List && (postData['attachments'] as List).isNotEmpty) {
+      print('[HomeFeedScreen _addPost] Type of first attachment element: ${(postData['attachments'] as List).first.runtimeType}');
+    }
     final result = await dataController.createPost(postData);
 
     if (result['success'] == true) {


### PR DESCRIPTION
…ed-screen.dart`. This will help us understand the structure of `postData` and its `attachments` list right before it's sent to the backend. This should help us figure out that "Converting object to an encodable object failed: Instance of 'Attachment'" error you've been seeing.